### PR TITLE
[nrf noup] add partition manager patches

### DIFF
--- a/boot/zephyr/include/target.h
+++ b/boot/zephyr/include/target.h
@@ -8,6 +8,8 @@
 #ifndef H_TARGETS_TARGET_
 #define H_TARGETS_TARGET_
 
+#ifndef USE_PARTITION_MANAGER
+
 #if defined(MCUBOOT_TARGET_CONFIG)
 /*
  * Target-specific definitions are permitted in legacy cases that
@@ -46,5 +48,7 @@
                                      !(FLASH_AREA_LABEL_EXISTS(image_3)))
 #error "Target support is incomplete; cannot build mcuboot."
 #endif
+
+#endif /* ifndef USE_PARTITION_MANAGER */
 
 #endif /* H_TARGETS_TARGET_ */


### PR DESCRIPTION
There is no need to verify the target when using partition manager.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>